### PR TITLE
Fix store getters using undefined variable

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -46,10 +46,11 @@ export default new Vuex.Store({
       })
       return flattenArticles
     },
-    prominentblog: state => {
-      var prominentblog = {}
+    prominentblog: (state, getters) => {
+      const articles = getters.articles
+      let prominentblog = {}
 
-      for (const article of flattenArticles) {
+      for (const article of articles) {
         if (article.prominent) {
           prominentblog = article
         }
@@ -57,10 +58,11 @@ export default new Vuex.Store({
 
       return prominentblog
     },
-    categories: state => {
+    categories: (state, getters) => {
+      const articles = getters.articles
       const categories = []
 
-      for (const article of flattenArticles) {
+      for (const article of articles) {
         if (
           !article.category ||
           categories.find(category => category.text === article.category)


### PR DESCRIPTION
## Summary
- fix prominentblog and categories getters to reference articles

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bd2539aa0832697485e7f22604c9c