### PR TITLE
Add sitemap generator and robots configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
     "deploy": "yarn build && now && now alias",
-    "i18n:report": "vue-cli-service i18n:report --src './src/**/*.?(js|vue)' --locales './src/locales/**/*.json'"
+    "i18n:report": "vue-cli-service i18n:report --src './src/**/*.?(js|vue)' --locales './src/locales/**/*.json'",
+    "sitemap": "node scripts/generate-sitemap.js"
   },
   "dependencies": {
     "emailjs-com": "^2.4.1",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Allow: /
+Allow: /blog
+Allow: /book
+Allow: /there
+Allow: /home
+Sitemap: https://www.aimeecotetherapy.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.aimeecotetherapy.com/</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/blog</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/book</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/there</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/home</loc>
+  </url>
+</urlset>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+
+const baseUrl = 'https://www.aimeecotetherapy.com';
+const routes = ['/', '/blog', '/book', '/there', '/home'];
+
+const urls = routes
+  .map(route => `  <url>\n    <loc>${baseUrl}${route}</loc>\n  </url>`)
+  .join('\n');
+
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
+
+const outputPath = path.join(__dirname, '..', 'public', 'sitemap.xml');
+fs.writeFileSync(outputPath, sitemap);
+console.log('sitemap.xml generated at', outputPath);


### PR DESCRIPTION
## Summary
- add robots.txt with allowed directories and sitemap reference
- add sitemap generator script and generated sitemap
- expose sitemap generation via npm script

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: command "lint" does not exist)*
- `npm run sitemap`


------
https://chatgpt.com/codex/tasks/task_e_68b740cba1d08326aa14bbcfc9a8947a