### PR TITLE
feat: integrate vue-meta for page metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "vue": "^2.6.11",
     "vue-i18n": "^8.17.3",
     "vue-router": "^3.1.6",
+    "vue-meta": "^2.4.0",
     "vue-youtube": "^1.4.0",
     "vue-youtube-embed": "^2.2.2",
     "vuelidate": "^0.7.5",

--- a/src/main.js
+++ b/src/main.js
@@ -6,8 +6,10 @@ import router from './router'
 import store from './store'
 import i18n from './i18n'
 import VueYouTubeEmbed from 'vue-youtube-embed'
+import VueMeta from 'vue-meta' // eslint-disable-line import/no-unresolved
  
 Vue.use(VueYouTubeEmbed)
+Vue.use(VueMeta)
 Vue.config.productionTip = false
 
 new Vue({

--- a/src/views/Blog.vue
+++ b/src/views/Blog.vue
@@ -12,5 +12,14 @@
       Articles: () => import('@/components/home/Articles'),
       Banner: () => import('@/components/home/Banner'),
     },
+    metaInfo: {
+      title: 'Blog',
+      meta: [
+        {
+          name: 'description',
+          content: 'Latest therapy articles and news from Aimee Co Therapy'
+        }
+      ]
+    }
   }
 </script>

--- a/src/views/BlogEntry.vue
+++ b/src/views/BlogEntry.vue
@@ -15,5 +15,16 @@
 <script>
   export default {
     name: 'BlogEntry',
+    metaInfo () {
+      return {
+        title: this.$i18n.t(this.$route.params.title),
+        meta: [
+          {
+            name: 'description',
+            content: this.$i18n.t(this.$route.params.content)
+          }
+        ]
+      }
+    }
   }
 </script>

--- a/src/views/Book.vue
+++ b/src/views/Book.vue
@@ -10,5 +10,14 @@ class="mt-10"
     components: {
       BookView: () => import('@/components/core/BookView'),
     },
+    metaInfo: {
+      title: 'Book a Session',
+      meta: [
+        {
+          name: 'description',
+          content: 'Schedule a therapy appointment with Aimee Co Therapy'
+        }
+      ]
+    }
   }
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -25,5 +25,14 @@
       NewToTherapy: () => import('@/components/NewToTherapy'),
       MyApproach: () => import('@/components/MyApproach'),
     },
+    metaInfo: {
+      title: 'Home',
+      meta: [
+        {
+          name: 'description',
+          content: 'Overview of therapy services and approach at Aimee Co Therapy'
+        }
+      ]
+    }
   }
 </script>

--- a/src/views/There.vue
+++ b/src/views/There.vue
@@ -8,5 +8,14 @@
     components: {
       GettingThere: () => import('@/components/core/GettingThere'),
     },
+    metaInfo: {
+      title: 'Getting There',
+      meta: [
+        {
+          name: 'description',
+          content: 'Directions and contact information for visiting Aimee Co Therapy'
+        }
+      ]
+    }
   }
 </script>


### PR DESCRIPTION
## Summary
- configure vue-meta in main entry to support page metadata
- define unique titles and meta descriptions for all view components
- declare vue-meta dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: command "lint" does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b740cf551483268c8e397af7db90be