### PR TITLE
Add Google Analytics tracking snippet

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,6 +17,17 @@
          emailjs.init("user_uCSQHcEpjWGwhD3pfhcYT");
        })();
     </script>
+
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-0WB5D5N0FV"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-0WB5D5N0FV');
+    </script>
+    <!-- End Google Analytics -->
   </head>
   <body>
     <noscript>


### PR DESCRIPTION
## Summary
- integrate Google Analytics tracking snippet in `public/index.html` with measurement ID

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: command "lint" does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b740da0cf48326acc5a662a37332e9