### PR TITLE
fix: prevent mobile overflow on home and map pages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -32,3 +32,10 @@ export default {
   }
 };
 </script>
+
+<style>
+html,
+body {
+  overflow-x: hidden;
+}
+</style>

--- a/src/components/Asystem.vue
+++ b/src/components/Asystem.vue
@@ -5,7 +5,8 @@
     <br />
     <v-img
       :src="require(`@/assets/closeup-photography-of-stacked-stones.jpg`)"
-      width="50vh"
+      width="100%"
+      style="max-width:50vh;"
       class="float-md-right mx-auto my-12 ma-md-12"
     />
     <base-heading>

--- a/src/components/FamilyTherapyRow.vue
+++ b/src/components/FamilyTherapyRow.vue
@@ -12,7 +12,7 @@
     >
       <v-sheet
         width="100%"
-        class="ma-5 pa-1"
+        class="my-5 pa-1"
       >
         <base-text>
           <h1 align="center">

--- a/src/components/FamilyTherapyTable.vue
+++ b/src/components/FamilyTherapyTable.vue
@@ -1,7 +1,8 @@
 <template>
   <v-card
     elevation="1"
-    width="740px"
+    width="100%"
+    style="max-width:740px;"
     class="mx-auto"
     align="center"
   >
@@ -19,7 +20,8 @@
           v-if="card.section_title"
           color="transparent"
           outlined="false"
-          width="740px"
+          width="100%"
+          style="max-width:740px;"
           class="fill-height"
         >
           <v-card-text class="display-2 accent--text pa-12">

--- a/src/components/MyApproach.vue
+++ b/src/components/MyApproach.vue
@@ -2,25 +2,24 @@
   <section
     id="myapproach"
   >
-    <v-row>
-      <v-divider />
+    <v-divider />
 
-      <v-container>
+    <v-container>
         <v-img
           :src="require(`@/assets/family.jpg`)"
           width="100%"
           style="max-width:50vh;"
           class="float-md-left mx-auto ma-md-12"
         />
-        <base-heading class="ma-5">
+        <base-heading class="my-5">
           <h1>{{ $t('MyApproachTitle') }}</h1>
         </base-heading>
         <base-text>
           <br><br>
           <p v-html="$i18n.t('myapproach')" />
         </base-text>
-      </v-container>
-      <v-container>
+    </v-container>
+    <v-container>
         <v-img
           :src="require(`@/assets/shutterstock_1316614289.jpg`)"
           width="100%"
@@ -31,7 +30,6 @@
           <br><br><br><br>
           <p v-html="$i18n.t('myapproach2')" />
         </base-text>
-      </v-container>
-    </v-row>
+    </v-container>
   </section>
 </template>

--- a/src/components/MyApproach.vue
+++ b/src/components/MyApproach.vue
@@ -8,7 +8,8 @@
       <v-container>
         <v-img
           :src="require(`@/assets/family.jpg`)"
-          width="50vh"
+          width="100%"
+          style="max-width:50vh;"
           class="float-md-left mx-auto ma-md-12"
         />
         <base-heading class="ma-5">
@@ -22,7 +23,8 @@
       <v-container>
         <v-img
           :src="require(`@/assets/shutterstock_1316614289.jpg`)"
-          width="50vh"
+          width="100%"
+          style="max-width:50vh;"
           class="float-md-right mx-auto ma-md-12"
         />
         <base-text>

--- a/src/components/NewToTherapy.vue
+++ b/src/components/NewToTherapy.vue
@@ -3,7 +3,7 @@
     id="newtotherapy"
   >
     <v-divider />
-    <v-row>
+    <v-row no-gutters>
       <youtube
         :video-id="videoId"
       />

--- a/src/components/Welcome.vue
+++ b/src/components/Welcome.vue
@@ -13,7 +13,7 @@
           no-gutters
           align="center"
         >
-          <v-col class="ma-5 ma-md-12">
+          <v-col class="my-5 my-md-12">
             <v-img
               :src="require('@/assets/Aimee.jpg')"
               width="100%"

--- a/src/components/Welcome.vue
+++ b/src/components/Welcome.vue
@@ -13,7 +13,7 @@
           no-gutters
           align="center"
         >
-          <v-col class="my-5 my-md-12">
+          <v-col class="my-5 my-md-12 pa-2">
             <v-img
               :src="require('@/assets/Aimee.jpg')"
               width="100%"
@@ -31,7 +31,7 @@
           no-gutters
           align="center"
         >
-          <base-text class="py-12">
+          <base-text class="py-12 pl-md-6">
             <h1 class="display-3">
               {{ $i18n.t("WelcomeName") }}
             </h1>

--- a/src/components/WelcomeAlert.vue
+++ b/src/components/WelcomeAlert.vue
@@ -10,6 +10,7 @@
       class="height"
       align="center"
       justify="center"
+      no-gutters
     >
       <v-col
         cols="10"

--- a/src/components/core/AppBar.vue
+++ b/src/components/core/AppBar.vue
@@ -9,8 +9,8 @@
       @click="toggleDrawer"
     />
 
-    <v-container class="mx-auto py-0">
-      <v-row align="center">
+    <v-container class="mx-auto py-0" fluid>
+      <v-row align="center" no-gutters>
         <v-tooltip bottom>
           <template v-slot:activator="{ on }">
             <v-img

--- a/src/components/core/GettingThere.vue
+++ b/src/components/core/GettingThere.vue
@@ -15,10 +15,10 @@
       tabindex="0"
       class="mx-auto my-12"
     />
-    <base-heading class="ma-12">
+    <base-heading class="my-12">
       <h1>{{ $t('nav.there') }}</h1>
     </base-heading>
-    <base-text class="ma-12">
+    <base-text class="my-12">
       <p>{{ $t('GettingThereDescription') }}</p>
     </base-text>
     <v-img

--- a/src/components/core/GettingThere.vue
+++ b/src/components/core/GettingThere.vue
@@ -6,14 +6,14 @@
   >
     <iframe
       src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d3384.641460603695!2d2.1575746630360038!3d48.90570706464473!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47e6633498101fff%3A0x137b1a456c99b5da!2sAimee%20Cote%2C%20Therapist%2FPsychopraticienne!5e0!3m2!1sfr!2sus!4v1592126234552!5m2!1sfr!2sus"
-      width="600"
+      width="100%"
+      style="max-width:600px; border:0;"
       height="450"
       frameborder="0"
-      style="border:0;"
       allowfullscreen=""
       aria-hidden="false"
       tabindex="0"
-      class="float-left pa-12"
+      class="mx-auto my-12"
     />
     <base-heading class="ma-12">
       <h1>{{ $t('nav.there') }}</h1>
@@ -24,7 +24,8 @@
     <v-img
       :src="require(`@/assets/officeChatou.jpg`)"
       width="100%"
-      class="float-left ma-12"
+      style="max-width:600px;"
+      class="mx-auto my-12"
     />
   </section>
 </template>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,16 +1,16 @@
 <template>
   <div>
-    <welcome class="ma-5" />
+    <welcome class="my-5" />
 
-    <welcome-alert />
+    <welcome-alert class="my-5" />
 
-    <family class="ma-5" />
+    <family class="my-5" />
 
-    <asystem class="ma-5" />
+    <asystem class="my-5" />
 
-    <new-to-therapy class="ma-5" />
+    <new-to-therapy class="my-5" />
 
-    <my-approach class="ma-5" />
+    <my-approach class="my-5" />
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- make Getting There map and image responsive
- use responsive widths for home page images and therapy table
- remove app bar gutters and use a fluid container to keep top bar within screen width

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: vue-cli-service not found)
- `npm ci` (fails: 403 Forbidden - GET https://registry.npmjs.org/netlify-cms-app)


------
https://chatgpt.com/codex/tasks/task_e_68b949e908888326b9d4cd879f874c8a