### PR TITLE
feat: enable image lazy loading

### DIFF
--- a/src/components/AboutMe.vue
+++ b/src/components/AboutMe.vue
@@ -66,6 +66,7 @@
       >
         <v-img
           :src="require('@/assets/background-balance-beach-boulder.jpg')"
+          :lazy-src="require('@/assets/white_wall.png')"
           height="100%"
         />
       </v-col>

--- a/src/components/Asystem.vue
+++ b/src/components/Asystem.vue
@@ -5,6 +5,7 @@
     <br />
     <v-img
       :src="require(`@/assets/closeup-photography-of-stacked-stones.jpg`)"
+      :lazy-src="require('@/assets/white_wall.png')"
       width="100%"
       style="max-width:50vh;"
       class="float-md-right mx-auto my-12 ma-md-12"

--- a/src/components/FeedCard.vue
+++ b/src/components/FeedCard.vue
@@ -29,13 +29,14 @@
           <p
             v-html="value.content"
           />
-          <v-img
-            v-if="value.image != 'hide'"
-            class="mx-auto"
-            :src="require(`@/assets/articles/${value.image}`)"
-            onerror="this.onerror=null; this.src='Default.jpg'"
-            width="75%"
-          /></v-img>
+            <v-img
+              v-if="value.image != 'hide'"
+              class="mx-auto"
+              :src="require(`@/assets/articles/${value.image}`)"
+              :lazy-src="require('@/assets/white_wall.png')"
+              onerror="this.onerror=null; this.src='Default.jpg'"
+              width="75%"
+            />
 
         </v-col>
         <v-col class="d-flex justify-center align-center">
@@ -45,7 +46,6 @@
           />
         </v-col>
       </v-row>
-      </v-img>
     </base-card>
   </v-col>
 </template>

--- a/src/components/FeedReadMoreDisplay.vue
+++ b/src/components/FeedReadMoreDisplay.vue
@@ -12,6 +12,7 @@
         >
           <v-img
             :src="require(`@/assets/articles/${image}`)"
+            :lazy-src="require('@/assets/white_wall.png')"
             class="pt-16 float-none"
             height="50vh"
             contain="true"

--- a/src/components/GetInTouch.vue
+++ b/src/components/GetInTouch.vue
@@ -13,6 +13,7 @@
       >
         <v-img
           :src="require('@/assets/contact.png')"
+          :lazy-src="require('@/assets/white_wall.png')"
           height="100%"
         />
       </v-col>

--- a/src/components/Instagram.vue
+++ b/src/components/Instagram.vue
@@ -14,11 +14,12 @@
           height="88"
           tag="a"
         >
-          <v-img
-            v-if="post.src"
-            :src="require(`@/assets/instagram/${post.src}`)"
-            height="100%"
-          />
+        <v-img
+          v-if="post.src"
+          :src="require(`@/assets/instagram/${post.src}`)"
+          :lazy-src="require('@/assets/white_wall.png')"
+          height="100%"
+        />
         </base-card>
       </v-col>
     </v-row>

--- a/src/components/MyApproach.vue
+++ b/src/components/MyApproach.vue
@@ -7,6 +7,7 @@
     <v-container>
         <v-img
           :src="require(`@/assets/family.jpg`)"
+          :lazy-src="require('@/assets/white_wall.png')"
           width="100%"
           style="max-width:50vh;"
           class="float-md-left mx-auto ma-md-12"
@@ -22,6 +23,7 @@
     <v-container>
         <v-img
           :src="require(`@/assets/shutterstock_1316614289.jpg`)"
+          :lazy-src="require('@/assets/white_wall.png')"
           width="100%"
           style="max-width:50vh;"
           class="float-md-right mx-auto ma-md-12"

--- a/src/components/NewestPosts.vue
+++ b/src/components/NewestPosts.vue
@@ -14,6 +14,7 @@
       >
         <v-img
           :src="require(`@/assets/articles/${article.hero}`)"
+          :lazy-src="require('@/assets/white_wall.png')"
           class="mr-3"
           height="36"
           max-width="36"

--- a/src/components/Welcome.vue
+++ b/src/components/Welcome.vue
@@ -16,6 +16,7 @@
           <v-col class="my-5 my-md-12 pa-2">
             <v-img
               :src="require('@/assets/Aimee.jpg')"
+              :lazy-src="require('@/assets/white_wall.png')"
               width="100%"
               aspect-ratio="1"
             />

--- a/src/components/base/Bubble1.vue
+++ b/src/components/base/Bubble1.vue
@@ -6,6 +6,7 @@
     width="100%"
     position="top right"
     :src="require('@/assets/bubbles1.png')"
+    :lazy-src="require('@/assets/white_wall.png')"
   />
 </template>
 

--- a/src/components/base/Bubble2.vue
+++ b/src/components/base/Bubble2.vue
@@ -6,6 +6,7 @@
     width="100%"
     position="bottom left"
     :src="require('@/assets/bubbles2.png')"
+    :lazy-src="require('@/assets/white_wall.png')"
   />
 </template>
 

--- a/src/components/core/AppBar.vue
+++ b/src/components/core/AppBar.vue
@@ -15,6 +15,7 @@
           <template v-slot:activator="{ on }">
             <v-img
               :src="require('@/assets/logo.jpg')"
+              :lazy-src="require('@/assets/white_wall.png')"
               class="mr-5"
               contain
               height="48"

--- a/src/components/core/GettingThere.vue
+++ b/src/components/core/GettingThere.vue
@@ -23,6 +23,7 @@
     </base-text>
     <v-img
       :src="require(`@/assets/officeChatou.jpg`)"
+      :lazy-src="require('@/assets/white_wall.png')"
       width="100%"
       style="max-width:600px;"
       class="mx-auto my-12"

--- a/src/components/home/Banner.vue
+++ b/src/components/home/Banner.vue
@@ -2,6 +2,7 @@
   <base-card dark>
     <v-img
       :src="require('@/assetsBigsize/logo.jpg')"
+      :lazy-src="require('@/assets/white_wall.png')"
       class="grey lighten-2"
       height="400"
       width="100%"


### PR DESCRIPTION
## Summary
- add lazy-src placeholders to Vuetify v-img components for deferred loading
- tidy FeedCard image tag structure

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*
- `npm test` *(fails: Missing script "test" )*
- `npx lighthouse https://example.com` *(fails: 403 Forbidden accessing npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b95cf40dc883269140f5eedfa41ca1