### PR TITLE
Fix language selector width to remain visible

### DIFF
--- a/src/components/core/AppBar.vue
+++ b/src/components/core/AppBar.vue
@@ -47,7 +47,7 @@
           :items="langs"
           :label="$t('ChangeLanguage')"
           hide-details
-          style="max-width: 150px;"
+          style="width: 150px;"
           @change="changeLocale"
         />
       </v-row>


### PR DESCRIPTION
## Summary
- keep language selector dropdown width fixed so icon and label remain visible

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b972a2ef04832681f156ef5cf808e9