### PR TITLE
Render blog markdown with marked

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,13 @@
     "i18n:report": "vue-cli-service i18n:report --src './src/**/*.?(js|vue)' --locales './src/locales/**/*.json'",
     "sitemap": "node scripts/generate-sitemap.js"
   },
-  "dependencies": {
-    "emailjs-com": "^2.4.1",
-    "front-matter": "^4.0.2",
-    "slugify": "^1.6.5",
-    "vue": "^2.6.11",
-    "vue-i18n": "^8.17.3",
+    "dependencies": {
+      "emailjs-com": "^2.4.1",
+      "front-matter": "^4.0.2",
+      "marked": "^9.0.0",
+      "slugify": "^1.6.5",
+      "vue": "^2.6.11",
+      "vue-i18n": "^8.17.3",
     "vue-router": "^3.1.6",
     "vue-meta": "^2.4.0",
     "vue-youtube": "^1.4.0",

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,8 +2,10 @@ import Vue from 'vue'
 import Vuex from 'vuex'
 import fm from 'front-matter'
 import i18n from '@/i18n'
+import { marked } from 'marked'
 
 Vue.use(Vuex)
+marked.setOptions({ breaks: true })
 
 const markdownContext = require.context('!!raw-loader!../content/blog', true, /index\.[a-z]{2}\.md$/)
 
@@ -38,7 +40,10 @@ export default new Vuex.Store({
         .reverse()
         .map(key => {
           const { attributes, body } = fm(markdownContext(key).default)
-          return { ...attributes, content: body.trim() }
+          // Convert markdown content to HTML so line breaks and other formatting
+          // entered in the CMS editor are rendered properly on the website
+          const content = marked(body.trim())
+          return { ...attributes, content }
         })
     },
     prominentblog: (state, getters) => {


### PR DESCRIPTION
## Summary
- Parse blog markdown using the `marked` library so line breaks and formatting entered in CMS render correctly
- Add `marked` dependency for markdown-to-HTML conversion

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: vue-cli-service: not found)


------
https://chatgpt.com/codex/tasks/task_e_68ba0039886c8326a212196f9b72b653