### PR TITLE
feat: style CMS preview with site theme

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -6,5 +6,8 @@
 </head>
 <body>
   <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+  <script>
+    CMS.registerPreviewStyle("/admin/preview.css")
+  </script>
 </body>
 </html>

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -6,8 +6,6 @@
 </head>
 <body>
   <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
-  <script>
-    CMS.registerPreviewStyle("/admin/preview.css")
-  </script>
+  <script src="/admin/preview.js"></script>
 </body>
 </html>

--- a/public/admin/preview.css
+++ b/public/admin/preview.css
@@ -5,9 +5,33 @@
 body {
   font-family: 'Roboto', sans-serif;
   color: #2E5246;
-  background-color: #F0FFF0;
+  background-color: #FFFFFF;
 }
 
 a {
   color: #549480;
+}
+
+.category {
+  display: inline-block;
+  background-color: #1B5E20;
+  color: #FFFFFF;
+  padding: 4px 8px;
+  margin-bottom: 16px;
+  text-transform: uppercase;
+}
+
+.title {
+  color: #000000;
+  margin: 0 0 8px;
+}
+
+.author {
+  color: #000000;
+  font-size: 0.875rem;
+  margin-bottom: 16px;
+}
+
+.body {
+  font-size: 1rem;
 }

--- a/public/admin/preview.css
+++ b/public/admin/preview.css
@@ -35,3 +35,9 @@ a {
 .body {
   font-size: 1rem;
 }
+
+.image {
+  display: block;
+  max-width: 75%;
+  margin: 16px auto 0;
+}

--- a/public/admin/preview.css
+++ b/public/admin/preview.css
@@ -1,0 +1,13 @@
+@import url('https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900&display=swap');
+@import url('https://cdn.jsdelivr.net/npm/@mdi/font@5.x/css/materialdesignicons.min.css');
+@import url('https://use.fontawesome.com/releases/v5.0.13/css/all.css');
+
+body {
+  font-family: 'Roboto', sans-serif;
+  color: #2E5246;
+  background-color: #F0FFF0;
+}
+
+a {
+  color: #549480;
+}

--- a/public/admin/preview.js
+++ b/public/admin/preview.js
@@ -3,11 +3,14 @@ CMS.registerPreviewStyle("/admin/preview.css");
 const BlogPreview = createClass({
   render: function() {
     const entry = this.props.entry;
+    const image = entry.getIn(['data', 'image']);
+    const imageUrl = image ? this.props.getAsset(image) : null;
     return h('div', {},
       h('div', { className: 'category' }, entry.getIn(['data', 'category'])),
       h('h1', { className: 'title' }, entry.getIn(['data', 'title'])),
       h('p', { className: 'author' }, entry.getIn(['data', 'author'])),
-      h('div', { className: 'body' }, this.props.widgetFor('body'))
+      h('div', { className: 'body' }, this.props.widgetFor('body')),
+      imageUrl ? h('img', { className: 'image', src: imageUrl.toString(), alt: entry.getIn(['data', 'title']) }) : null
     );
   }
 });

--- a/public/admin/preview.js
+++ b/public/admin/preview.js
@@ -1,0 +1,15 @@
+CMS.registerPreviewStyle("/admin/preview.css");
+
+const BlogPreview = createClass({
+  render: function() {
+    const entry = this.props.entry;
+    return h('div', {},
+      h('div', { className: 'category' }, entry.getIn(['data', 'category'])),
+      h('h1', { className: 'title' }, entry.getIn(['data', 'title'])),
+      h('p', { className: 'author' }, entry.getIn(['data', 'author'])),
+      h('div', { className: 'body' }, this.props.widgetFor('body'))
+    );
+  }
+});
+
+CMS.registerPreviewTemplate('blog', BlogPreview);


### PR DESCRIPTION
## Summary
- add preview CSS matching blog fonts and colors
- load preview stylesheet in Netlify CMS admin

## Testing
- `npm test` (fails: Missing script "test")
- `npm install` (fails: 403 Forbidden to npm registry)

------
https://chatgpt.com/codex/tasks/task_e_68ba0ad38cb883269b4fb0b5f476eb9d