### PR TITLE
fix: display media library for blog images

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -12,6 +12,8 @@ collections:
   - name: "blog"
     label: "Blog"
     folder: "src/content/blog"
+    media_folder: "../../../public/img/uploads"
+    public_folder: "/img/uploads"
     create: true
     slug: "{{slug}}"
     path: "{{slug}}/index"


### PR DESCRIPTION
## Summary
- ensure Netlify CMS blog collection uses correct path for uploaded images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: vue-cli-service not found; dependency installation blocked 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8f3129ec8326a32ab103930c5a8a