### PR TITLE
Add basic page tests and test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "vue-cli-service lint",
     "deploy": "yarn build && now && now alias",
     "i18n:report": "vue-cli-service i18n:report --src './src/**/*.?(js|vue)' --locales './src/locales/**/*.json'",
-    "sitemap": "node scripts/generate-sitemap.js"
+    "sitemap": "node scripts/generate-sitemap.js",
+    "test": "jest"
   },
   "dependencies": {
     "emailjs-com": "^2.4.1",

--- a/tests/unit/pages.spec.js
+++ b/tests/unit/pages.spec.js
@@ -1,0 +1,77 @@
+import { shallowMount, createLocalVue } from '@vue/test-utils'
+import VueI18n from 'vue-i18n'
+import Vuex from 'vuex'
+import Home from '@/views/Home.vue'
+import Blog from '@/views/Blog.vue'
+import Welcome from '@/components/Welcome.vue'
+
+const localVue = createLocalVue()
+localVue.use(VueI18n)
+localVue.use(Vuex)
+
+const i18n = new VueI18n({
+  locale: 'en',
+  messages: {
+    en: {
+      WelcomeName: 'Aimee',
+      WelcomeTitle: 'Therapist',
+      WelcomeTitle2: 'A bilingual French - English therapist located in Chatou',
+      Welcome: '',
+      Welcome2: '',
+      pagination: { prev: '', next: '', page_of: 'Page {page} of {pages}' }
+    }
+  }
+})
+
+describe('Pages', () => {
+  test('home page contains bilingual tagline', () => {
+    const wrapper = shallowMount(Home, {
+      localVue,
+      i18n,
+      stubs: {
+        Welcome: Welcome,
+        WelcomeAlert: true,
+        Family: true,
+        Asystem: true,
+        NewToTherapy: true,
+        MyApproach: true
+      }
+    })
+    expect(wrapper.html()).toContain('A bilingual French - English therapist located in Chatou')
+  })
+
+  test('blog page lists blog articles', () => {
+    const store = new Vuex.Store({
+      getters: {
+        articles: () => [
+          { title: 'First post', content: 'Test content' }
+        ]
+      }
+    })
+
+    const wrapper = shallowMount(Blog, {
+      localVue,
+      i18n,
+      store,
+      stubs: {
+        Banner: true,
+        Articles: {
+          template: '<div><feed/></div>',
+          components: {
+            feed: {
+              template: '<div><feed-card v-for="a in articles" :key="a.title" /></div>',
+              computed: {
+                articles () {
+                  return this.$store.getters.articles
+                }
+              },
+              components: { 'feed-card': { template: '<div class="feed-card"></div>' } }
+            }
+          }
+        }
+      }
+    })
+
+    expect(wrapper.findAll('.feed-card').length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary
- add jest test script to package.json
- add unit tests to verify home tagline and blog listings

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe5af68588326a69f9b2f62227071