### PR TITLE
Set English as default locale

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -22,6 +22,6 @@ function loadLocaleMessages () {
 
 export default new VueI18n({
   locale: process.env.VUE_APP_I18N_LOCALE || 'en',
-  fallbackLocale: process.env.VUE_APP_I18N_FALLBACK_LOCALE || 'fr',
+  fallbackLocale: process.env.VUE_APP_I18N_FALLBACK_LOCALE || 'en',
   messages: loadLocaleMessages(),
 })

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,14 +9,14 @@ import i18n from '@/i18n'
 
 Vue.use(Router)
 
-const supportedLanguages = ['fr', 'en', 'es']
+const supportedLanguages = ['en', 'fr', 'es']
 
 function getBrowserLanguage () {
   if (typeof navigator !== 'undefined') {
     const browser = navigator.language.split('-')[0]
     if (supportedLanguages.includes(browser)) return browser
   }
-  return 'fr'
+  return 'en'
 }
 
 export default new Router({


### PR DESCRIPTION
## Summary
- Make English the default and fallback locale
- Default router redirects to English when no browser language is detected

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*
- `npm run lint` *(fails: vue-cli-service not found)*
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1baf3dd483269914cd348788bfa6