### PR TITLE
build: generate language-specific sitemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "build": "npm run sitemap && vue-cli-service build",
     "lint": "vue-cli-service lint",
     "deploy": "yarn build && now && now alias",
     "i18n:report": "vue-cli-service i18n:report --src './src/**/*.?(js|vue)' --locales './src/locales/**/*.json'",

--- a/public/en/sitemap.xml
+++ b/public/en/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.aimeecotetherapy.com/en/</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/en/blog</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/en/book</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/en/there</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/en/home</loc>
+  </url>
+</urlset>

--- a/public/es/sitemap.xml
+++ b/public/es/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.aimeecotetherapy.com/es/</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/es/blog</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/es/book</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/es/there</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/es/home</loc>
+  </url>
+</urlset>

--- a/public/fr/sitemap.xml
+++ b/public/fr/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.aimeecotetherapy.com/fr/</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/fr/blog</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/fr/book</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/fr/there</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/fr/home</loc>
+  </url>
+</urlset>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,7 +1,4 @@
 User-agent: *
 Allow: /
-Allow: /blog
-Allow: /book
-Allow: /there
-Allow: /home
+
 Sitemap: https://www.aimeecotetherapy.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,18 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://www.aimeecotetherapy.com/</loc>
-  </url>
-  <url>
-    <loc>https://www.aimeecotetherapy.com/blog</loc>
-  </url>
-  <url>
-    <loc>https://www.aimeecotetherapy.com/book</loc>
-  </url>
-  <url>
-    <loc>https://www.aimeecotetherapy.com/there</loc>
-  </url>
-  <url>
-    <loc>https://www.aimeecotetherapy.com/home</loc>
-  </url>
-</urlset>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://www.aimeecotetherapy.com/fr/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.aimeecotetherapy.com/en/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.aimeecotetherapy.com/es/sitemap.xml</loc>
+  </sitemap>
+</sitemapindex>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -3,13 +3,27 @@ const path = require('path');
 
 const baseUrl = 'https://www.aimeecotetherapy.com';
 const routes = ['/', '/blog', '/book', '/there', '/home'];
+const languages = ['fr', 'en', 'es'];
 
-const urls = routes
-  .map(route => `  <url>\n    <loc>${baseUrl}${route}</loc>\n  </url>`)
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+languages.forEach(lang => {
+  const urls = routes
+    .map(route => `  <url>\n    <loc>${baseUrl}/${lang}${route}</loc>\n  </url>`)
+    .join('\n');
+  const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
+  const dir = path.join(__dirname, '..', 'public', lang);
+  ensureDir(dir);
+  fs.writeFileSync(path.join(dir, 'sitemap.xml'), sitemap);
+});
+
+const indexEntries = languages
+  .map(lang => `  <sitemap>\n    <loc>${baseUrl}/${lang}/sitemap.xml</loc>\n  </sitemap>`)
   .join('\n');
+const sitemapIndex = `<?xml version="1.0" encoding="UTF-8"?>\n<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${indexEntries}\n</sitemapindex>\n`;
 
-const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
+fs.writeFileSync(path.join(__dirname, '..', 'public', 'sitemap.xml'), sitemapIndex);
+console.log('Generated sitemaps for languages:', languages.join(', '));
 
-const outputPath = path.join(__dirname, '..', 'public', 'sitemap.xml');
-fs.writeFileSync(outputPath, sitemap);
-console.log('sitemap.xml generated at', outputPath);


### PR DESCRIPTION
## Summary
- generate language-specific sitemaps and a root sitemap index
- run sitemap generation during build
- simplify robots.txt with sitemap reference

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*
- `npm run lint` *(fails: vue-cli-service not found)*
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc21e5e0708326b55f34ec4e8c126f