### PR TITLE
feat(blog): add slug routes and SEO sitemap

### DIFF
--- a/public/en/sitemap.xml
+++ b/public/en/sitemap.xml
@@ -15,4 +15,19 @@
   <url>
     <loc>https://www.aimeecotetherapy.com/en/home</loc>
   </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/en/blog/challenges-of-isolation-during-the-coronavirus-pandemic</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/en/blog/sitting-with-suffering-vs-the-trap-of-problem-solving</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/en/blog/dissociation</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/en/blog/beyond-behaviors-an-innovative-approach-to-challenging-behavior</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/en/blog/why-we-should-stop-blaming-inconsistent-parenting-for-those-epic-meltdowns</loc>
+  </url>
 </urlset>

--- a/public/es/sitemap.xml
+++ b/public/es/sitemap.xml
@@ -15,4 +15,19 @@
   <url>
     <loc>https://www.aimeecotetherapy.com/es/home</loc>
   </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/es/blog/los-retos-del-aislamiento-durante-la-pandemia-de-coronavirus</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/es/blog/acompanar-el-sufrimiento-frente-a-la-trampa-de-solucionar-el-problema</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/es/blog/disociacion</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/es/blog/beyond-behaviors-un-enfoque-innovador-para-los-comportamientos-desafiantes</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/es/blog/por-que-deberiamos-dejar-de-culpar-a-la-falta-de-constancia-parental-por-esas-rabietas-epicas</loc>
+  </url>
 </urlset>

--- a/public/fr/sitemap.xml
+++ b/public/fr/sitemap.xml
@@ -15,4 +15,19 @@
   <url>
     <loc>https://www.aimeecotetherapy.com/fr/home</loc>
   </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/fr/blog/les-defis-de-lisolement-pendant-la-pandemie-de-coronavirus</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/fr/blog/rester-avec-la-souffrance-vs-le-piege-de-la-recherche-de-solutions</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/fr/blog/dissociation</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/fr/blog/beyond-behaviors-une-approche-innovante-des-comportements-difficiles</loc>
+  </url>
+  <url>
+    <loc>https://www.aimeecotetherapy.com/fr/blog/pourquoi-nous-devrions-arreter-de-blamer-linconstance-parentale-pour-ces-crises-spectaculaires</loc>
+  </url>
 </urlset>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,18 @@
 User-agent: *
 Allow: /
-
+Allow: /fr/blog/les-defis-de-lisolement-pendant-la-pandemie-de-coronavirus
+Allow: /fr/blog/rester-avec-la-souffrance-vs-le-piege-de-la-recherche-de-solutions
+Allow: /fr/blog/dissociation
+Allow: /fr/blog/beyond-behaviors-une-approche-innovante-des-comportements-difficiles
+Allow: /fr/blog/pourquoi-nous-devrions-arreter-de-blamer-linconstance-parentale-pour-ces-crises-spectaculaires
+Allow: /en/blog/challenges-of-isolation-during-the-coronavirus-pandemic
+Allow: /en/blog/sitting-with-suffering-vs-the-trap-of-problem-solving
+Allow: /en/blog/dissociation
+Allow: /en/blog/beyond-behaviors-an-innovative-approach-to-challenging-behavior
+Allow: /en/blog/why-we-should-stop-blaming-inconsistent-parenting-for-those-epic-meltdowns
+Allow: /es/blog/los-retos-del-aislamiento-durante-la-pandemia-de-coronavirus
+Allow: /es/blog/acompanar-el-sufrimiento-frente-a-la-trampa-de-solucionar-el-problema
+Allow: /es/blog/disociacion
+Allow: /es/blog/beyond-behaviors-un-enfoque-innovador-para-los-comportamientos-desafiantes
+Allow: /es/blog/por-que-deberiamos-dejar-de-culpar-a-la-falta-de-constancia-parental-por-esas-rabietas-epicas
 Sitemap: https://www.aimeecotetherapy.com/sitemap.xml

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,16 +1,37 @@
 const fs = require('fs');
 const path = require('path');
+const fm = require('front-matter');
+const slugify = require('slugify');
 
 const baseUrl = 'https://www.aimeecotetherapy.com';
 const routes = ['/', '/blog', '/book', '/there', '/home'];
 const languages = ['fr', 'en', 'es'];
+const blogDir = path.join(__dirname, '..', 'src', 'content', 'blog');
 
-function ensureDir(dir) {
+function ensureDir (dir) {
   fs.mkdirSync(dir, { recursive: true });
 }
 
+function getBlogRoutes (lang) {
+  const dirs = fs.readdirSync(blogDir).filter(name => fs.statSync(path.join(blogDir, name)).isDirectory());
+  const slugs = new Set();
+  dirs.forEach(d => {
+    const file = path.join(blogDir, d, `index.${lang}.md`);
+    const content = fs.readFileSync(file, 'utf-8');
+    const { attributes } = fm(content);
+    const slug = slugify(attributes.title, { lower: true, strict: true });
+    slugs.add(`/blog/${slug}`);
+  });
+  return Array.from(slugs);
+}
+
+const blogRoutesByLang = languages.reduce((acc, lang) => {
+  acc[lang] = getBlogRoutes(lang);
+  return acc;
+}, {});
+
 languages.forEach(lang => {
-  const urls = routes
+  const urls = [...routes, ...blogRoutesByLang[lang]]
     .map(route => `  <url>\n    <loc>${baseUrl}/${lang}${route}</loc>\n  </url>`)
     .join('\n');
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
@@ -25,5 +46,13 @@ const indexEntries = languages
 const sitemapIndex = `<?xml version="1.0" encoding="UTF-8"?>\n<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${indexEntries}\n</sitemapindex>\n`;
 
 fs.writeFileSync(path.join(__dirname, '..', 'public', 'sitemap.xml'), sitemapIndex);
-console.log('Generated sitemaps for languages:', languages.join(', '));
+
+const robotLines = Object.entries(blogRoutesByLang)
+  .flatMap(([lang, routes]) => routes.map(route => `Allow: /${lang}${route}`))
+  .join('\n');
+
+const robots = `User-agent: *\nAllow: /\n${robotLines ? robotLines + '\n' : ''}Sitemap: ${baseUrl}/sitemap.xml\n`;
+fs.writeFileSync(path.join(__dirname, '..', 'public', 'robots.txt'), robots);
+
+console.log('Generated sitemaps and robots for languages:', languages.join(', '));
 

--- a/src/components/FeedCard.vue
+++ b/src/components/FeedCard.vue
@@ -5,6 +5,7 @@
   >
     <base-card
       color="lighten-10"
+      @click="navigateTo(value.slug)"
     >
       <v-row
         class="fill-height ma-0"
@@ -69,8 +70,8 @@
       overlay: false,
     }),
     methods: {
-      navigateTo (title, content, image) {
-        this.$router.push({ name: 'blogentry', params: { title: title, content: content, image: image } })
+      navigateTo (slug) {
+        this.$router.push({ name: 'blogentry', params: { lang: this.$route.params.lang, slug } })
       },
     },
   }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -38,7 +38,7 @@ export default new Router({
       children: [
         { path: '', name: 'home', component: Home },
         { path: 'blog', name: 'blog', component: Blog },
-        { path: 'blogentry/:title/:content/:image', name: 'blogentry', component: BlogEntry },
+        { path: 'blog/:slug', name: 'blogentry', component: BlogEntry },
         { path: 'book', name: 'book', component: Book },
         { path: 'there', name: 'there', component: There },
       ],

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
 import fm from 'front-matter'
+import slugify from 'slugify'
 import i18n from '@/i18n'
 
 Vue.use(Vuex)
@@ -38,7 +39,8 @@ export default new Vuex.Store({
         .reverse()
         .map(key => {
           const { attributes, body } = fm(markdownContext(key).default)
-          return { ...attributes, content: body.trim() }
+          const slug = slugify(attributes.title, { lower: true, strict: true })
+          return { ...attributes, slug, content: body.trim() }
         })
     },
     prominentblog: (state, getters) => {

--- a/src/views/BlogEntry.vue
+++ b/src/views/BlogEntry.vue
@@ -21,6 +21,11 @@
       {{ article.author }}
     </div>
     <br>
+    <p
+      class="black--text"
+      v-html="article.content"
+    />
+    <br>
     <v-img
       v-if="article.image && article.image !== 'hide'"
       class="mx-auto"
@@ -29,11 +34,6 @@
       :alt="article.title"
       onerror="this.onerror=null; this.src='Default.jpg'"
       width="75%"
-    />
-    <br>
-    <p
-      class="black--text"
-      v-html="article.content"
     />
   </div>
 </template>

--- a/src/views/BlogEntry.vue
+++ b/src/views/BlogEntry.vue
@@ -17,8 +17,8 @@
     name: 'BlogEntry',
     computed: {
       article () {
-        const title = this.$route.params.title
-        return this.$store.getters.articles.find(a => a.title === title) || {}
+        const slug = this.$route.params.slug
+        return this.$store.getters.articles.find(a => a.slug === slug) || {}
       }
     },
     metaInfo () {

--- a/src/views/BlogEntry.vue
+++ b/src/views/BlogEntry.vue
@@ -1,12 +1,38 @@
 <template>
   <div class="ma-5">
     <br>
+    <v-chip
+      v-if="article.category"
+      label
+      class="mx-0 mb-2 text-uppercase"
+      color="green darken-3"
+      text-color="white"
+      small
+    >
+      {{ article.category }}
+    </v-chip>
     <h1 class="black--text">
       {{ article.title }}
     </h1>
+    <div
+      v-if="article.author"
+      class="caption"
+    >
+      {{ article.author }}
+    </div>
+    <br>
+    <v-img
+      v-if="article.image && article.image !== 'hide'"
+      class="mx-auto"
+      :src="article.image"
+      :lazy-src="require('@/assets/white_wall.png')"
+      :alt="article.title"
+      onerror="this.onerror=null; this.src='Default.jpg'"
+      width="75%"
+    />
     <br>
     <p
-      class="black--text "
+      class="black--text"
       v-html="article.content"
     />
   </div>

--- a/tests/blog-meta.spec.js
+++ b/tests/blog-meta.spec.js
@@ -3,12 +3,14 @@ import Vuex from 'vuex'
 import VueMeta from 'vue-meta'
 import BlogEntry from '@/views/BlogEntry.vue'
 
+jest.mock('@/assets/white_wall.png', () => '')
+
 const localVue = createLocalVue()
 localVue.use(Vuex)
 localVue.use(VueMeta)
 
 describe('BlogEntry meta tags', () => {
-  it('renders title and description meta tags', () => {
+  it('renders article details and meta tags', () => {
     const store = new Vuex.Store({
       getters: {
         articles: () => [
@@ -16,7 +18,10 @@ describe('BlogEntry meta tags', () => {
             title: 'Test Article',
             description: 'A short description',
             content: '<p>Content</p>',
-            slug: 'test-article'
+            slug: 'test-article',
+            category: 'News',
+            author: 'John Doe',
+            image: '/img.jpg'
           }
         ]
       }
@@ -27,7 +32,8 @@ describe('BlogEntry meta tags', () => {
       store,
       mocks: {
         $route: { params: { slug: 'test-article' } }
-      }
+      },
+      stubs: ['v-chip', 'v-img']
     })
 
       const meta = wrapper.vm.$meta().refresh()
@@ -55,5 +61,9 @@ describe('BlogEntry meta tags', () => {
       const twitterDesc = meta.metaInfo.meta.find(m => m.name === 'twitter:description')
       expect(twitterDesc).toBeTruthy()
       expect(twitterDesc.content).toBe('A short description')
+
+      expect(wrapper.find('v-chip-stub').text()).toBe('News')
+      expect(wrapper.find('.caption').text()).toBe('John Doe')
+      expect(wrapper.find('v-img-stub').attributes('src')).toBe('/img.jpg')
   })
 })

--- a/tests/blog-meta.spec.js
+++ b/tests/blog-meta.spec.js
@@ -15,7 +15,8 @@ describe('BlogEntry meta tags', () => {
           {
             title: 'Test Article',
             description: 'A short description',
-            content: '<p>Content</p>'
+            content: '<p>Content</p>',
+            slug: 'test-article'
           }
         ]
       }
@@ -25,7 +26,7 @@ describe('BlogEntry meta tags', () => {
       localVue,
       store,
       mocks: {
-        $route: { params: { title: 'Test Article' } }
+        $route: { params: { slug: 'test-article' } }
       }
     })
 


### PR DESCRIPTION
## Summary
- support slug-based blog entry routes
- generate robots and sitemap entries for each blog post
- link feed cards to new blog routes

## Testing
- `npm run lint` *(fails: command "lint" does not exist)*
- `npx eslint src` *(fails: Configuration for rule "vue/max-attributes-per-line" is invalid)*
- `npm test`
- `CI=1 npm run build` *(fails: ENOENT: no such file or directory, open 'dist/legacy-assets-index.html.json')*

------
https://chatgpt.com/codex/tasks/task_e_68bc4618a7b083269cd7f05cf88ebc94