### PR TITLE
feat: add Lighthouse SEO check script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This file provides guidance for automated agents working in this repository.
 - This project uses Node.js (>=22) and Vue.js.
 - Use `npm install` to add dependencies and update `package-lock.json` when needed.
 - Build the project with `npm run build` to verify production readiness.
+- Run `npm run seo-check` to audit SEO metadata across locales.
 
 ## 1) Environment invariants
 

--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ Uncertainty about the future, anxiety about our well being and our loved ones' h
 ```
 
 Add images to `public/img/uploads`.
+
+## SEO checks
+
+Use `npm run seo-check` to run Lighthouse in CI mode against all localized
+pages. Set the `SITE_URL` environment variable to point to the deployed site
+or leave it unset to check a local server at `http://localhost:8080`.

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,0 +1,27 @@
+const locales = ['en', 'fr', 'es']
+const baseUrl = process.env.SITE_URL || 'http://localhost:8080'
+
+module.exports = {
+  ci: {
+    collect: {
+      url: locales.map(locale => `${baseUrl}/${locale}/`),
+      numberOfRuns: 1,
+      settings: {
+        onlyCategories: ['seo'],
+        chromeFlags: '--headless'
+      }
+    },
+    assert: {
+      assertions: {
+        'seo/document-title': 'error',
+        'seo/meta-description': 'error',
+        'seo/hreflang': 'error',
+        'seo/canonical': 'error',
+        'seo/structured-data': 'error'
+      }
+    },
+    upload: {
+      target: 'temporary-public-storage'
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "i18n:report": "vue-cli-service i18n:report --src './src/**/*.?(js|vue)' --locales './src/locales/**/*.json'",
     "sitemap": "node scripts/generate-sitemap.js",
     "versions": "node -v && npm -v && npx vue-cli-service --version",
-    "test": "jest"
+    "test": "jest",
+    "seo-check": "npx lhci autorun --config=lighthouserc.js"
   },
   "dependencies": {
     "emailjs-com": "^2.4.1",


### PR DESCRIPTION
## Summary
- add `seo-check` npm script and Lighthouse CI config for SEO validation across locales
- document SEO audit usage in README
- require `npm run seo-check` in `AGENTS.md`

## Testing
- `npm run lint`
- `npm test`
- `CI=1 npm run build`
- `npm run seo-check` *(fails: 403 Forbidden from registry.npmjs.org/lhci)*

------
https://chatgpt.com/codex/tasks/task_e_68bc680d2c6c83268f92c01f9435e8c1