### PR TITLE
Enable Netlify prerendering and optimize images

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,13 @@
   NODE_VERSION = "22"
   NPM_VERSION  = "11.4.2"
   NPM_FLAGS    = "--include=dev"
+
+[[plugins]]
+  package = "@netlify/plugin-prerender"
+  [plugins.inputs]
+    crawl = true
+
+[[plugins]]
+  package = "netlify-plugin-image-optim"
+  [plugins.inputs]
+    formats = ["webp", "avif"]

--- a/src/components/base/Bubble1.vue
+++ b/src/components/base/Bubble1.vue
@@ -1,15 +1,15 @@
 <template>
-  <v-img
-    class="grow hidden-sm-and-down"
-    contain
-    max-height="200"
-    width="100%"
-    position="top right"
-    :src="require('@/assets/bubbles1.png')"
-    :lazy-src="require('@/assets/white_wall.png')"
-    alt="Decorative bubble"
-  />
-</template>
+    <v-img
+      class="grow hidden-sm-and-down"
+      contain
+      max-height="200"
+      width="100%"
+      position="top right"
+      :src="'/.netlify/images?url=' + require('@/assets/bubbles1.png') + '&format=auto'"
+      :lazy-src="require('@/assets/white_wall.png')"
+      :alt="$t('DecorativeBubbleAlt')"
+    />
+  </template>
 
 <script>
   export default {

--- a/src/components/base/Bubble2.vue
+++ b/src/components/base/Bubble2.vue
@@ -1,15 +1,15 @@
 <template>
-  <v-img
-    class="grow hidden-sm-and-down"
-    contain
-    max-height="200"
-    width="100%"
-    position="bottom left"
-    :src="require('@/assets/bubbles2.png')"
-    :lazy-src="require('@/assets/white_wall.png')"
-    alt="Decorative bubble"
-  />
-</template>
+    <v-img
+      class="grow hidden-sm-and-down"
+      contain
+      max-height="200"
+      width="100%"
+      position="bottom left"
+      :src="'/.netlify/images?url=' + require('@/assets/bubbles2.png') + '&format=auto'"
+      :lazy-src="require('@/assets/white_wall.png')"
+      :alt="$t('DecorativeBubbleAlt')"
+    />
+  </template>
 
 <script>
   export default {

--- a/src/components/core/AppBar.vue
+++ b/src/components/core/AppBar.vue
@@ -13,21 +13,21 @@
       <v-row align="center" no-gutters>
         <v-tooltip bottom>
           <template v-slot:activator="{ on }">
-            <v-img
-              :src="require('@/assets/logo.jpg')"
-              :lazy-src="require('@/assets/white_wall.png')"
-              class="mr-5"
-              contain
-              height="48"
-              width="48"
-              max-width="48"
-              alt="Aimee Cote Therapy logo"
-              @click="$vuetify.goTo(0)"
-              v-on="on"
-            />
-          </template>
-          <span>{{ $t('TooltipTherapist') }}</span>
-        </v-tooltip>
+              <v-img
+                src="/.netlify/images?url=/logo.jpg&format=auto"
+                :lazy-src="require('@/assets/white_wall.png')"
+                class="mr-5"
+                contain
+                height="48"
+                width="48"
+                max-width="48"
+                :alt="$t('LogoAlt')"
+                @click="$vuetify.goTo(0)"
+                v-on="on"
+              />
+            </template>
+            <span>{{ $t('TooltipTherapist') }}</span>
+          </v-tooltip>
         <v-btn
           v-for="(link, i) in links"
           :key="i"

--- a/src/components/home/Banner.vue
+++ b/src/components/home/Banner.vue
@@ -1,13 +1,13 @@
 <template>
   <base-card dark>
-    <v-img
-      :src="require('@/assetsBigsize/logo.jpg')"
-      :lazy-src="require('@/assets/white_wall.png')"
-      alt="Aimee Cote Therapy logo"
-      class="grey lighten-2"
-      height="400"
-      width="100%"
-    >
+      <v-img
+        :src="'/.netlify/images?url=' + require('@/assetsBigsize/logo.jpg') + '&format=auto'"
+        :lazy-src="require('@/assets/white_wall.png')"
+        :alt="$t('LogoAlt')"
+        class="grey lighten-2"
+        height="400"
+        width="100%"
+      >
       <v-row
         class="fill-height"
         align="start"

--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -49,5 +49,7 @@
   "InstagramPigDuckAlt": "Pig and duck figurines",
   "InstagramRainAlt": "Rain falling outside",
   "InstagramSpicesAlt": "Assorted spices",
-  "InstagramSunsetAlt": "Vibrant sunset"
+  "InstagramSunsetAlt": "Vibrant sunset",
+  "LogoAlt": "Aimee Cote Therapy logo",
+  "DecorativeBubbleAlt": "Decorative bubble"
 }

--- a/src/locales/es/es.json
+++ b/src/locales/es/es.json
@@ -92,6 +92,9 @@
   "InstagramPigDuckAlt": "Figuras de cerdo y pato",
   "InstagramRainAlt": "Lluvia cayendo afuera",
   "InstagramSpicesAlt": "Especias variadas",
-  "InstagramSunsetAlt": "Puesta de sol vibrante"
+  "InstagramSunsetAlt": "Puesta de sol vibrante",
+  "LogoAlt": "Logotipo de Aimee Cote Therapy",
+  "DecorativeBubbleAlt": "Burbuja decorativa"
 }
+
 

--- a/src/locales/fr/fr.json
+++ b/src/locales/fr/fr.json
@@ -91,5 +91,7 @@
   "InstagramPigDuckAlt": "Figurines de cochon et de canard",
   "InstagramRainAlt": "Pluie tombant dehors",
   "InstagramSpicesAlt": "Assortiment d'épices",
-  "InstagramSunsetAlt": "Coucher de soleil éclatant"
+  "InstagramSunsetAlt": "Coucher de soleil éclatant",
+  "LogoAlt": "Logo d'Aimee Cote Therapy",
+  "DecorativeBubbleAlt": "Bulle décorative"
 }


### PR DESCRIPTION
## Summary
- configure Netlify prerender plugin and image optimizer to produce WebP/AVIF
- translate image alt text and request modern formats via Netlify Image CDN

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run seo-check` *(fails: 403 Forbidden fetching lhci)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6bef840c8326b0f57b38b96dc13a