### PR TITLE
Add structured data JSON-LD across core views

### DIFF
--- a/src/buildGraphFor.js
+++ b/src/buildGraphFor.js
@@ -1,0 +1,44 @@
+export default function buildGraphFor (routeName = 'home', lang = 'en', t = k => k) {
+  const base = 'https://aimeecotetherapy.com'
+  const routes = {
+    home: { navKey: 'nav.home', titleKey: 'meta.homeTitle', path: '' },
+    blog: { navKey: 'nav.blog', titleKey: 'meta.blogTitle', path: '/blog' },
+    book: { navKey: 'nav.book', titleKey: 'meta.bookTitle', path: '/book' },
+    there: { navKey: 'nav.there', titleKey: 'meta.thereTitle', path: '/there' }
+  }
+
+  const info = routes[routeName] || routes.home
+  const path = info.path
+  const url = `${base}/${lang}${path}/`
+  const breadcrumbs = [
+    { '@type': 'ListItem', position: 1, name: t(routes.home.navKey), item: `${base}/${lang}/` }
+  ]
+  if (path) {
+    breadcrumbs.push({ '@type': 'ListItem', position: 2, name: t(info.navKey), item: url })
+  }
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'WebPage',
+        '@id': url,
+        url,
+        name: t(info.titleKey),
+        isPartOf: {
+          '@type': 'WebSite',
+          name: 'Aimee Cote Therapy',
+          url: base + '/'
+        },
+        about: {
+          '@type': 'Organization',
+          name: 'Aimee Cote Therapy'
+        }
+      },
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: breadcrumbs
+      }
+    ]
+  }
+}

--- a/src/views/Blog.vue
+++ b/src/views/Blog.vue
@@ -6,6 +6,8 @@
 </template>
 
 <script>
+  import buildGraphFor from '@/buildGraphFor'
+
   export default {
     name: 'Blog',
     components: {
@@ -15,6 +17,8 @@
     metaInfo () {
       const path = this.$route?.path || '/'
       const canonical = `https://aimeecotetherapy.com${path.endsWith('/') ? path : path + '/'}`
+      const routeName = this.$route?.name
+      const lang = this.$i18n?.locale || this.$route?.params.lang || 'en'
       return {
         title: this.$t('meta.blogTitle'),
         meta: [
@@ -25,6 +29,12 @@
         ],
         link: [
           { vmid: 'canonical', rel: 'canonical', href: canonical }
+        ],
+        script: [
+          {
+            type: 'application/ld+json',
+            json: buildGraphFor(routeName, lang, this.$t.bind(this))
+          }
         ]
       }
     }

--- a/src/views/Book.vue
+++ b/src/views/Book.vue
@@ -5,6 +5,8 @@ class="mt-10"
 </template>
 
 <script>
+  import buildGraphFor from '@/buildGraphFor'
+
   export default {
     name: 'Book',
     components: {
@@ -13,6 +15,8 @@ class="mt-10"
     metaInfo () {
       const path = this.$route?.path || '/'
       const canonical = `https://aimeecotetherapy.com${path.endsWith('/') ? path : path + '/'}`
+      const routeName = this.$route?.name
+      const lang = this.$i18n?.locale || this.$route?.params.lang || 'en'
       return {
         title: this.$t('meta.bookTitle'),
         meta: [
@@ -23,6 +27,12 @@ class="mt-10"
         ],
         link: [
           { vmid: 'canonical', rel: 'canonical', href: canonical }
+        ],
+        script: [
+          {
+            type: 'application/ld+json',
+            json: buildGraphFor(routeName, lang, this.$t.bind(this))
+          }
         ]
       }
     }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -15,6 +15,8 @@
 </template>
 
 <script>
+  import buildGraphFor from '@/buildGraphFor'
+
   export default {
     name: 'Home',
     components: {
@@ -28,6 +30,8 @@
     metaInfo () {
       const path = this.$route?.path || '/'
       const canonical = `https://aimeecotetherapy.com${path.endsWith('/') ? path : path + '/'}`
+      const routeName = this.$route?.name
+      const lang = this.$i18n?.locale || this.$route?.params.lang || 'en'
       return {
         title: this.$t('meta.homeTitle'),
         meta: [
@@ -38,6 +42,12 @@
         ],
         link: [
           { vmid: 'canonical', rel: 'canonical', href: canonical }
+        ],
+        script: [
+          {
+            type: 'application/ld+json',
+            json: buildGraphFor(routeName, lang, this.$t.bind(this))
+          }
         ]
       }
     }

--- a/src/views/There.vue
+++ b/src/views/There.vue
@@ -3,6 +3,8 @@
 </template>
 
 <script>
+  import buildGraphFor from '@/buildGraphFor'
+
   export default {
     name: 'There',
     components: {
@@ -11,6 +13,8 @@
     metaInfo () {
       const path = this.$route?.path || '/'
       const canonical = `https://aimeecotetherapy.com${path.endsWith('/') ? path : path + '/'}`
+      const routeName = this.$route?.name
+      const lang = this.$i18n?.locale || this.$route?.params.lang || 'en'
       return {
         title: this.$t('meta.thereTitle'),
         meta: [
@@ -21,6 +25,12 @@
         ],
         link: [
           { vmid: 'canonical', rel: 'canonical', href: canonical }
+        ],
+        script: [
+          {
+            type: 'application/ld+json',
+            json: buildGraphFor(routeName, lang, this.$t.bind(this))
+          }
         ]
       }
     }


### PR DESCRIPTION
## Summary
- generate localized JSON-LD graphs in `buildGraphFor` based on current route and language
- pass locale-aware data from Home, Blog, Book and There views for accurate structured metadata

## Testing
- `npx eslint src/buildGraphFor.js src/views/Home.vue src/views/Blog.vue src/views/Book.vue src/views/There.vue` *(fails: Parsing error: Class extends value [object Module] is not a constructor or null)*
- `npm run lint` *(fails: Parsing error: Class extends value [object Module] is not a constructor or null)*
- `npm test`
- `CI=1 npm run build`
- `npx --yes lhci autorun --config=lighthouserc.js` *(fails: Need to install the following packages: lhci@4.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_68be87e1ecc4832693f731b8063b0da7