### PR TITLE
Add structured data for blog entries

### DIFF
--- a/src/views/BlogEntry.vue
+++ b/src/views/BlogEntry.vue
@@ -52,6 +52,24 @@
       const description = this.article.description || ''
       const path = this.$route?.path || '/'
       const canonical = `https://aimeecotetherapy.com${path.endsWith('/') ? path : path + '/'}`
+      const articleGraph = {
+        '@type': 'Article',
+        '@id': `${canonical}#article`,
+        headline: title,
+        datePublished: this.article.date,
+        image: this.article.image,
+        author: { '@type': 'Person', name: this.article.author },
+        isPartOf: {
+          '@type': 'WebSite',
+          name: 'Aimee Cote Therapy',
+          url: 'https://aimeecotetherapy.com/'
+        },
+        about: {
+          '@type': 'LocalBusiness',
+          name: 'Aimee Cote Therapy',
+          url: 'https://aimeecotetherapy.com/'
+        }
+      }
       return {
         title,
         meta: [
@@ -64,6 +82,12 @@
         ],
         link: [
           { vmid: 'canonical', rel: 'canonical', href: canonical }
+        ],
+        script: [
+          {
+            type: 'application/ld+json',
+            json: { '@context': 'https://schema.org', '@graph': [articleGraph] }
+          }
         ]
       }
     }

--- a/tests/blog-meta.spec.js
+++ b/tests/blog-meta.spec.js
@@ -21,7 +21,8 @@ describe('BlogEntry meta tags', () => {
             slug: 'test-article',
             category: 'News',
             author: 'John Doe',
-            image: '/img.jpg'
+            image: '/img.jpg',
+            date: '2024-01-01'
           }
         ]
       }
@@ -31,7 +32,7 @@ describe('BlogEntry meta tags', () => {
       localVue,
       store,
       mocks: {
-        $route: { params: { slug: 'test-article' } }
+        $route: { params: { slug: 'test-article' }, path: '/en/blog/test-article' }
       },
       stubs: ['v-chip', 'v-img']
     })
@@ -65,5 +66,17 @@ describe('BlogEntry meta tags', () => {
       expect(wrapper.find('v-chip-stub').text()).toBe('News')
       expect(wrapper.find('.caption').text()).toBe('John Doe')
       expect(wrapper.find('v-img-stub').attributes('src')).toBe('/img.jpg')
+
+      const script = meta.metaInfo.script.find(s => s.type === 'application/ld+json')
+      expect(script).toBeTruthy()
+      const graph = script.json['@graph']
+      const article = graph.find(g => g['@type'] === 'Article')
+      expect(article).toBeTruthy()
+      expect(article.headline).toBe('Test Article')
+      expect(article.datePublished).toBe('2024-01-01')
+      expect(article.image).toBe('/img.jpg')
+      expect(article.author.name).toBe('John Doe')
+      expect(article.isPartOf['@type']).toBe('WebSite')
+      expect(article.about['@type']).toBe('LocalBusiness')
   })
 })


### PR DESCRIPTION
## Summary
- add JSON-LD Article object with WebSite and LocalBusiness references to blog entries
- verify structured data in blog meta tests

## Testing
- `npm run lint` *(fails: Parsing error: Class extends value [object Module] is not a constructor or null)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be94b87b3083269425496f8d5ba7e3