### PR TITLE
Fix breadcrumb and duplicate Article schema for Google Search Console

### DIFF
--- a/public/en/sitemap.xml
+++ b/public/en/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://aimeecotetherapy.com/en/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/"/>
@@ -10,7 +10,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/en/blog/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/"/>
@@ -18,7 +18,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/en/book/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/book/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/book/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/book/"/>
@@ -26,7 +26,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/en/there/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/there/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/there/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/there/"/>
@@ -34,7 +34,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/en/faq/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/faq/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/faq/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/faq/"/>
@@ -42,7 +42,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/en/blog/blog1/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog1/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog1/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog1/"/>
@@ -50,7 +50,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/en/blog/blog14/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog14/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog14/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog14/"/>
@@ -58,7 +58,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/en/blog/blog15/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog15/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog15/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog15/"/>
@@ -66,7 +66,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/en/blog/blog2/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog2/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog2/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog2/"/>
@@ -74,7 +74,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/en/blog/blog3/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog3/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog3/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog3/"/>
@@ -82,7 +82,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/en/blog/blog4/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog4/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog4/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog4/"/>
@@ -90,7 +90,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/en/blog/blog5/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog5/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog5/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog5/"/>

--- a/public/es/sitemap.xml
+++ b/public/es/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://aimeecotetherapy.com/es/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/"/>
@@ -10,7 +10,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/es/blog/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/"/>
@@ -18,7 +18,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/es/book/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/book/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/book/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/book/"/>
@@ -26,7 +26,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/es/there/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/there/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/there/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/there/"/>
@@ -34,7 +34,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/es/faq/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/faq/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/faq/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/faq/"/>
@@ -42,7 +42,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/es/blog/blog1/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog1/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog1/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog1/"/>
@@ -50,7 +50,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/es/blog/blog14/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog14/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog14/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog14/"/>
@@ -58,7 +58,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/es/blog/blog15/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog15/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog15/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog15/"/>
@@ -66,7 +66,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/es/blog/blog2/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog2/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog2/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog2/"/>
@@ -74,7 +74,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/es/blog/blog3/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog3/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog3/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog3/"/>
@@ -82,7 +82,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/es/blog/blog4/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog4/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog4/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog4/"/>
@@ -90,7 +90,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/es/blog/blog5/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog5/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog5/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog5/"/>

--- a/public/fr/sitemap.xml
+++ b/public/fr/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://aimeecotetherapy.com/fr/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/"/>
@@ -10,7 +10,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/fr/blog/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/"/>
@@ -18,7 +18,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/fr/book/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/book/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/book/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/book/"/>
@@ -26,7 +26,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/fr/there/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/there/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/there/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/there/"/>
@@ -34,7 +34,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/fr/faq/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/faq/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/faq/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/faq/"/>
@@ -42,7 +42,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/fr/blog/blog1/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog1/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog1/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog1/"/>
@@ -50,7 +50,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/fr/blog/blog14/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog14/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog14/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog14/"/>
@@ -58,7 +58,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/fr/blog/blog15/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog15/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog15/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog15/"/>
@@ -66,7 +66,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/fr/blog/blog2/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog2/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog2/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog2/"/>
@@ -74,7 +74,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/fr/blog/blog3/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog3/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog3/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog3/"/>
@@ -82,7 +82,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/fr/blog/blog4/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog4/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog4/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog4/"/>
@@ -90,7 +90,7 @@
   </url>
   <url>
     <loc>https://aimeecotetherapy.com/fr/blog/blog5/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-04-04</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://aimeecotetherapy.com/fr/blog/blog5/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://aimeecotetherapy.com/en/blog/blog5/"/>
     <xhtml:link rel="alternate" hreflang="es" href="https://aimeecotetherapy.com/es/blog/blog5/"/>

--- a/scripts/generate-static-html.js
+++ b/scripts/generate-static-html.js
@@ -483,6 +483,47 @@ function injectArticleSchema (html, schemaJson) {
   )
 }
 
+function generateBreadcrumbSchema (lang, routePath, pageName, locale) {
+  const homeName = locale['nav.home'] || 'Home'
+  const breadcrumbs = [
+    { '@type': 'ListItem', position: 1, name: homeName, item: `${baseUrl}/${lang}/` }
+  ]
+  if (routePath) {
+    breadcrumbs.push({
+      '@type': 'ListItem',
+      position: 2,
+      name: pageName,
+      item: `${baseUrl}/${lang}${routePath}/`
+    })
+  }
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: breadcrumbs
+  })
+}
+
+function generateBlogEntryBreadcrumbSchema (lang, slug, blogTitle, locale) {
+  const homeName = locale['nav.home'] || 'Home'
+  const blogName = locale['nav.blog'] || 'Blog'
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: homeName, item: `${baseUrl}/${lang}/` },
+      { '@type': 'ListItem', position: 2, name: blogName, item: `${baseUrl}/${lang}/blog/` },
+      { '@type': 'ListItem', position: 3, name: blogTitle, item: `${baseUrl}/${lang}/blog/${slug}/` }
+    ]
+  })
+}
+
+function injectBreadcrumbSchema (html, schemaJson) {
+  return html.replace(
+    '</head>',
+    `<script type="application/ld+json">${schemaJson}</script>\n</head>`
+  )
+}
+
 // ──────────────────────────────────────────────────────────────
 // MAIN GENERATION LOOP
 // ──────────────────────────────────────────────────────────────
@@ -513,6 +554,7 @@ languages.forEach(lang => {
     const canonical = `${baseUrl}/${lang}/`
     let html = replaceMetaTags(shellHtml, { title, description, canonical, routePath })
     html = injectBodyContent(html, generateHomeContent(locale, lang))
+    html = injectBreadcrumbSchema(html, generateBreadcrumbSchema(lang, '', title, locale))
     const outputPath = path.join(distDir, lang, 'index.html')
     writeHtml(outputPath, html)
     generated++
@@ -553,6 +595,9 @@ languages.forEach(lang => {
       html = injectBodyContent(html, bodyHtml)
     }
 
+    // Inject BreadcrumbList schema for all static pages
+    html = injectBreadcrumbSchema(html, generateBreadcrumbSchema(lang, routePath, title, locale))
+
     const outputPath = path.join(distDir, lang, routePath.slice(1), 'index.html')
     writeHtml(outputPath, html)
     generated++
@@ -583,6 +628,7 @@ languages.forEach(lang => {
       lang === 'fr' ? 'thérapie Chatou' : lang === 'es' ? 'terapia Chatou' : 'therapy Chatou'
     ].filter(Boolean).join(', ')
     html = replaceMetaKeywords(html, blogKeywords)
+    html = injectBreadcrumbSchema(html, generateBlogEntryBreadcrumbSchema(lang, slug, title, locale))
 
     const outputPath = path.join(distDir, lang, 'blog', slug, 'index.html')
     writeHtml(outputPath, html)

--- a/src/views/Blog.vue
+++ b/src/views/Blog.vue
@@ -6,8 +6,6 @@
 </template>
 
 <script>
-  import buildGraphFor from '@/buildGraphFor'
-
   export default {
     name: 'Blog',
     components: {
@@ -17,8 +15,8 @@
     metaInfo () {
       const path = this.$route?.path || '/'
       const canonical = `https://aimeecotetherapy.com${path.endsWith('/') ? path : path + '/'}`
-      const routeName = this.$route?.name
-      const lang = this.$i18n?.locale || this.$route?.params.lang || 'en'
+      // BreadcrumbList schema is injected by generate-static-html.js in the pre-rendered HTML.
+      // Do NOT add it here via vue-meta to avoid duplicate structured data.
       return {
         title: this.$t('meta.blogTitle'),
         meta: [
@@ -29,12 +27,6 @@
         ],
         link: [
           { vmid: 'canonical', rel: 'canonical', href: canonical }
-        ],
-        script: [
-          {
-            type: 'application/ld+json',
-            json: buildGraphFor(routeName, lang, this.$t.bind(this))
-          }
         ]
       }
     }

--- a/src/views/BlogEntry.vue
+++ b/src/views/BlogEntry.vue
@@ -52,26 +52,8 @@
       const description = this.article.description || ''
       const path = this.$route?.path || '/'
       const canonical = `https://aimeecotetherapy.com${path.endsWith('/') ? path : path + '/'}`
-      const lang = this.$i18n?.locale || this.$route?.params.lang || 'en'
-      const articleGraph = {
-        '@type': 'Article',
-        '@id': `${canonical}#article`,
-        headline: title,
-        datePublished: this.article.date,
-        image: this.article.image,
-        author: { '@type': 'Person', name: this.article.author },
-        inLanguage: lang,
-        isPartOf: {
-          '@type': 'WebSite',
-          name: 'Aimee Cote Therapy',
-          url: 'https://aimeecotetherapy.com/'
-        },
-        about: {
-          '@type': 'LocalBusiness',
-          name: 'Aimee Cote Therapy',
-          url: 'https://aimeecotetherapy.com/'
-        }
-      }
+      // Article and BreadcrumbList schemas are injected by generate-static-html.js in the pre-rendered HTML.
+      // Do NOT add them here via vue-meta to avoid duplicate structured data.
       return {
         title,
         meta: [
@@ -87,12 +69,6 @@
         ],
         link: [
           { vmid: 'canonical', rel: 'canonical', href: canonical }
-        ],
-        script: [
-          {
-            type: 'application/ld+json',
-            json: { '@context': 'https://schema.org', '@graph': [articleGraph] }
-          }
         ]
       }
     }

--- a/src/views/Book.vue
+++ b/src/views/Book.vue
@@ -5,8 +5,6 @@ class="mt-10"
 </template>
 
 <script>
-  import buildGraphFor from '@/buildGraphFor'
-
   export default {
     name: 'Book',
     components: {
@@ -15,8 +13,8 @@ class="mt-10"
     metaInfo () {
       const path = this.$route?.path || '/'
       const canonical = `https://aimeecotetherapy.com${path.endsWith('/') ? path : path + '/'}`
-      const routeName = this.$route?.name
-      const lang = this.$i18n?.locale || this.$route?.params.lang || 'en'
+      // BreadcrumbList schema is injected by generate-static-html.js in the pre-rendered HTML.
+      // Do NOT add it here via vue-meta to avoid duplicate structured data.
       return {
         title: this.$t('meta.bookTitle'),
         meta: [
@@ -27,12 +25,6 @@ class="mt-10"
         ],
         link: [
           { vmid: 'canonical', rel: 'canonical', href: canonical }
-        ],
-        script: [
-          {
-            type: 'application/ld+json',
-            json: buildGraphFor(routeName, lang, this.$t.bind(this))
-          }
         ]
       }
     }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -17,8 +17,6 @@
 </template>
 
 <script>
-  import buildGraphFor from '@/buildGraphFor'
-
   export default {
     name: 'Home',
     components: {
@@ -33,8 +31,8 @@
     metaInfo () {
       const path = this.$route?.path || '/'
       const canonical = `https://aimeecotetherapy.com${path.endsWith('/') ? path : path + '/'}`
-      const routeName = this.$route?.name
-      const lang = this.$i18n?.locale || this.$route?.params.lang || 'en'
+      // BreadcrumbList schema is injected by generate-static-html.js in the pre-rendered HTML.
+      // Do NOT add it here via vue-meta to avoid duplicate structured data.
       return {
         title: this.$t('meta.homeTitle'),
         meta: [
@@ -45,12 +43,6 @@
         ],
         link: [
           { vmid: 'canonical', rel: 'canonical', href: canonical }
-        ],
-        script: [
-          {
-            type: 'application/ld+json',
-            json: buildGraphFor(routeName, lang, this.$t.bind(this))
-          }
         ]
       }
     }

--- a/src/views/There.vue
+++ b/src/views/There.vue
@@ -3,8 +3,6 @@
 </template>
 
 <script>
-  import buildGraphFor from '@/buildGraphFor'
-
   export default {
     name: 'There',
     components: {
@@ -13,8 +11,8 @@
     metaInfo () {
       const path = this.$route?.path || '/'
       const canonical = `https://aimeecotetherapy.com${path.endsWith('/') ? path : path + '/'}`
-      const routeName = this.$route?.name
-      const lang = this.$i18n?.locale || this.$route?.params.lang || 'en'
+      // BreadcrumbList schema is injected by generate-static-html.js in the pre-rendered HTML.
+      // Do NOT add it here via vue-meta to avoid duplicate structured data.
       return {
         title: this.$t('meta.thereTitle'),
         meta: [
@@ -25,12 +23,6 @@
         ],
         link: [
           { vmid: 'canonical', rel: 'canonical', href: canonical }
-        ],
-        script: [
-          {
-            type: 'application/ld+json',
-            json: buildGraphFor(routeName, lang, this.$t.bind(this))
-          }
         ]
       }
     }


### PR DESCRIPTION
Add BreadcrumbList JSON-LD schema to all pre-rendered static pages (home, blog list, book, there, faq, blog entries) via generate-static-html.js. Remove client-side schema injection from Vue components (Home, Blog, Book, There, BlogEntry) to prevent duplicate structured data that Google invalidates. Blog entries get 3-level breadcrumbs (Home > Blog > Article Title).